### PR TITLE
Add `lint` GitHub Actions workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,52 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install SARIF tools
+      run: cargo install clippy-sarif sarif-fmt
+    - name: Run clippy
+      run: >
+        cargo clippy --all-targets --message-format=json -- -D warnings
+        | clippy-sarif
+        | tee clippy-results.sarif
+        | sarif-fmt
+      continue-on-error: true
+    - name: Upload results
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: clippy-results.sarif
+        wait-for-processing: true
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run rustfmt
+      run: cargo fmt --all --check
+  committed:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Lint commits
+      uses: crate-ci/committed@master
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Spell check
+      uses: crate-ci/typos@master

--- a/committed.toml
+++ b/committed.toml
@@ -1,0 +1,2 @@
+style="conventional"
+merge_commit = false


### PR DESCRIPTION
Opposed to the `build & test` action, these run on linux to make it easier for me to reproduce them if something goes wrong.